### PR TITLE
reduce complexity in forkOrForkBlockPlayScanner

### DIFF
--- a/app/src/main/java/io/github/yamin8000/dooz/domain/ai/SimpleGameAi.kt
+++ b/app/src/main/java/io/github/yamin8000/dooz/domain/ai/SimpleGameAi.kt
@@ -170,9 +170,13 @@ class SimpleGameAi(
         for (cells in gameCells) {
             if (!cells.isSuspectToFork(playerType)) continue
             for (intersectingCells in compareGameCells) {
-                if (!intersectingCells.isSuspectToFork(playerType)) continue
+                if (!intersectingCells.isSuspectToFork(playerType)) {
+                    continue
+                }
                 val cell = checkForkIntersection(cells, intersectingCells, isBlocking)
-                if (cell != null) return cell
+                if (cell != null) {
+                    return cell
+                }
             }
         }
         return null
@@ -183,12 +187,22 @@ class SimpleGameAi(
         intersectingCells: List<DoozCell>,
         isBlocking: Boolean
     ): DoozCell? {
-        val cellOwner = cells.find { it.owner != null }?.owner ?: return null
-        val intersectOwner = intersectingCells.find { it.owner != null }?.owner ?: return null
-        if (cellOwner != intersectOwner) return null
+        val cellOwner = cells.find { it.owner != null }?.owner
+        if (cellOwner == null) {
+            return null
+        }
+        val intersectOwner = intersectingCells.find { it.owner != null }?.owner
+        if (intersectOwner == null) {
+            return null
+        }
+        if (cellOwner != intersectOwner) {
+            return null
+        }
         if (isBlocking) {
             val forceBlockCell = findCellForOpponentForceBlock()
-            if (forceBlockCell != null) return forceBlockCell
+            if (forceBlockCell != null) {
+                return forceBlockCell
+            }
         }
         return cells.filter { it.owner == null }
             .intersect(intersectingCells.filter { it.owner == null }.toSet())

--- a/app/src/main/java/io/github/yamin8000/dooz/domain/ai/SimpleGameAi.kt
+++ b/app/src/main/java/io/github/yamin8000/dooz/domain/ai/SimpleGameAi.kt
@@ -167,31 +167,32 @@ class SimpleGameAi(
         isBlocking: Boolean
     ): DoozCell? {
         val playerType = if (isBlocking) PlayerType.Human else PlayerType.Computer
-
-        for (i in gameCells.indices) {
-            val cells = gameCells.getOrNull(i) ?: continue
+        for (cells in gameCells) {
             if (!cells.isSuspectToFork(playerType)) continue
-
-            for (j in compareGameCells.indices) {
-                val intersectingCells = compareGameCells.getOrNull(j) ?: continue
+            for (intersectingCells in compareGameCells) {
                 if (!intersectingCells.isSuspectToFork(playerType)) continue
-
-                if (cells.find { it.owner != null }?.owner == intersectingCells.find { it.owner != null }?.owner) {
-                    if (isBlocking) {
-                        val forceBlockCell = findCellForOpponentForceBlock()
-                        if (forceBlockCell != null)
-                            return forceBlockCell
-                    }
-
-                    val cell = cells.filter { it.owner == null }
-                        .intersect(intersectingCells.filter { it.owner == null }.toSet())
-                        .firstOrNull()
-                    if (cell != null && cell.owner == null)
-                        return cell
-                }
+                val cell = checkForkIntersection(cells, intersectingCells, isBlocking)
+                if (cell != null) return cell
             }
         }
         return null
+    }
+
+    private fun checkForkIntersection(
+        cells: List<DoozCell>,
+        intersectingCells: List<DoozCell>,
+        isBlocking: Boolean
+    ): DoozCell? {
+        val cellOwner = cells.find { it.owner != null }?.owner ?: return null
+        val intersectOwner = intersectingCells.find { it.owner != null }?.owner ?: return null
+        if (cellOwner != intersectOwner) return null
+        if (isBlocking) {
+            val forceBlockCell = findCellForOpponentForceBlock()
+            if (forceBlockCell != null) return forceBlockCell
+        }
+        return cells.filter { it.owner == null }
+            .intersect(intersectingCells.filter { it.owner == null }.toSet())
+            .firstOrNull()
     }
 
     private fun findCellForOpponentForceBlock(): DoozCell? {


### PR DESCRIPTION
Closes #240

Extracts the intersection-checking logic inside `forkOrForkBlockPlayScanner` into a new private helper `checkForkIntersection`. This breaks up the deeply nested loop+conditional structure into two focused methods, each with a single responsibility — addressing the CodeFactor complexity warning.

Changes:
- `forkOrForkBlockPlayScanner`: simplified to iterate and delegate per-pair logic, uses idiomatic `for (x in list)` instead of index-based loops
- `checkForkIntersection` (new): handles owner matching and the blocking/intersection cell selection for a given pair of lines